### PR TITLE
feat: support configurable service name

### DIFF
--- a/AUTOHEALING.MD
+++ b/AUTOHEALING.MD
@@ -10,6 +10,7 @@ excerpt of config values specific to autohealing process below:
 $ doctor --help
 Usage of doctor:
       --autoheal                                          whether doctor should take active measures to attempt to heal the kava process (e.g. place on standby if it falls significantly behind live)
+      --autoheal_blockchain_service_name string           the name of the systemd service running the blockchain. this is the service that gets restarted in the autoheal process (default "kava")
       --autoheal_restart_delay_seconds int                number of seconds autohealing routines will wait to restart the endpoint, effective from the last time it was restarted and over riding the values downtime_restart_threshold_seconds no_new_blocks_restart_threshold_seconds (default 2700)
       --autoheal_sync_latency_tolerance_seconds int       how far behind live the node is allowed to fall before autohealing actions are attempted (default 120)
       --autoheal_sync_to_live_tolerance_seconds int       how close to the current time the node must resync to before being considered in sync again (default 12)
@@ -40,3 +41,7 @@ If doctor detects that the node has fallen more than `autoheal_sync_latency_tole
 ### Node API Frozen
 
 If doctor detects that the node has not synched a new block in more than `no_new_blocks_restart_threshold_seconds`, it will attempt to restart the kava process on the node.
+
+## Configurable service name
+
+The autohealing process assumes the chain is running via a systemd service. It uses a systemd restart to restart the chain. The name of this service is configurable via the configuration option `autoheal_blockchain_service_name`. By default, doctor uses the service name `kava`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Kava application and node infrastructure health monitoring daemon with configura
 $ doctor --help
 Usage of doctor:
       --autoheal                                          whether doctor should take active measures to attempt to heal the kava process (e.g. place on standby if it falls significantly behind live)
+      --autoheal_blockchain_service_name string           the name of the systemd service running the blockchain. this is the service that gets restarted in the autoheal process (default "kava")
       --autoheal_restart_delay_seconds int                number of seconds autohealing routines will wait to restart the endpoint, effective from the last time it was restarted and over riding the values downtime_restart_threshold_seconds no_new_blocks_restart_threshold_seconds (default 2700)
       --autoheal_sync_latency_tolerance_seconds int       how far behind live the node is allowed to fall before autohealing actions are attempted (default 120)
       --autoheal_sync_to_live_tolerance_seconds int       how close to the current time the node must resync to before being considered in sync again (default 12)
@@ -48,6 +49,7 @@ An example configuration file is provided below:
     "metric_namespace": "kava/mainnet-archive",
     "aws_region": "us-east-1",
     "autoheal": true,
+    "autoheal_blockchain_service_name": "kava",
     "autoheal_sync_latency_tolerance_seconds": 120,
     "autoheal_sync_to_live_tolerance_seconds": 12,
     "downtime_restart_threshold_seconds": 300,

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ const (
 	AWSRegionFlagName                                  = "aws_region"
 	MetricNamespaceFlagName                            = "metric_namespace"
 	AutohealFlagName                                   = "autoheal"
+	AutohealBlockchainServiceNameFlagName              = "autoheal_blockchain_service_name"
 	AutohealSyncLatencyToleranceSecondsFlagName        = "autoheal_sync_latency_tolerance_seconds"
 	AutohealSyncToLiveToleranceSecondsFlagName         = "autoheal_sync_to_live_tolerance_seconds"
 	DowntimeRestartThresholdSecondsFlagName            = "downtime_restart_threshold_seconds"
@@ -77,6 +78,7 @@ var (
 	awsRegionFlag                                  = flag.String(AWSRegionFlagName, "us-east-1", "aws region to use for sending metrics to CloudWatch")
 	metricNamespaceFlag                            = flag.String(MetricNamespaceFlagName, "kava", "top level namespace to use for grouping all metrics sent to cloudwatch")
 	autohealFlag                                   = flag.Bool(AutohealFlagName, false, "whether doctor should take active measures to attempt to heal the kava process (e.g. place on standby if it falls significantly behind live)")
+	autohealBlockchainServiceNameFlag              = flag.String(AutohealBlockchainServiceNameFlagName, "kava", "the name of the systemd service running the blockchain. this is the service that gets restarted in the autoheal process")
 	autohealSyncLatencyToleranceSecondsFlag        = flag.Int(AutohealSyncLatencyToleranceSecondsFlagName, 120, "how far behind live the node is allowed to fall before autohealing actions are attempted")
 	autohealSyncToLiveToleranceSecondsFlag         = flag.Int(AutohealSyncToLiveToleranceSecondsFlagName, 12, "how close to the current time the node must resync to before being considered in sync again")
 	downtimeRestartThresholdSecondsFlag            = flag.Int(DowntimeRestartThresholdSecondsFlagName, DefaultDowntimeRestartThresholdSeconds, "how many continuous seconds the endpoint being monitored has to be offline or unresponsive before autohealing will be attempted")
@@ -99,6 +101,7 @@ type DoctorConfig struct {
 	MetricNamespace                            string
 	Logger                                     *log.Logger
 	Autoheal                                   bool
+	AutohealBlockchainServiceName              string
 	AutohealSyncLatencyToleranceSeconds        int
 	AutohealSyncToLiveToleranceSeconds         int
 	AutohealRestartDelaySeconds                int
@@ -198,6 +201,7 @@ func GetDoctorConfig() (*DoctorConfig, error) {
 		AWSRegion:                           viper.GetString(AWSRegionFlagName),
 		MetricNamespace:                     viper.GetString(MetricNamespaceFlagName),
 		Autoheal:                            viper.GetBool(AutohealFlagName),
+		AutohealBlockchainServiceName:       viper.GetString(AutohealBlockchainServiceNameFlagName),
 		AutohealSyncLatencyToleranceSeconds: viper.GetInt(AutohealSyncLatencyToleranceSecondsFlagName),
 		AutohealSyncToLiveToleranceSeconds:  viper.GetInt(AutohealSyncToLiveToleranceSecondsFlagName),
 		AutohealRestartDelaySeconds:         viper.GetInt(AutohealRestartDelaySecondsFlagName),

--- a/heal/heal.go
+++ b/heal/heal.go
@@ -154,7 +154,7 @@ func StandbyNodeUntilCaughtUp(logMessages chan<- string, kavaClient *kava.Client
 			}
 
 			if currentState == autoscaling.LifecycleStateInService {
-				logMessages <- fmt.Sprint("StandbyNodeUntilCaughtUp: host is no longer on standby")
+				logMessages <- "StandbyNodeUntilCaughtUp: host is no longer on standby"
 
 				exitedStandby = true
 
@@ -184,14 +184,14 @@ func StandbyNodeUntilCaughtUp(logMessages chan<- string, kavaClient *kava.Client
 	logMessages <- "StandbyNodeUntilCaughtUp: node healed successfully by doctor"
 }
 
-// RestartKavaService restarts the kava service
+// RestartBlockchainService restarts the blockchain service
 // returning error (if any)
-func RestartKavaService() error {
+func RestartBlockchainService() error {
 	cmd := exec.Command("bash", "-c", "sudo systemctl restart kava")
 	output, err := cmd.CombinedOutput()
 
 	if err != nil {
-		return fmt.Errorf("error %s starting kava service output %s", err, string(output))
+		return fmt.Errorf("error %s starting blockchain service output %s", err, string(output))
 	}
 
 	return nil

--- a/heal/heal.go
+++ b/heal/heal.go
@@ -184,14 +184,13 @@ func StandbyNodeUntilCaughtUp(logMessages chan<- string, kavaClient *kava.Client
 	logMessages <- "StandbyNodeUntilCaughtUp: node healed successfully by doctor"
 }
 
-// RestartBlockchainService restarts the blockchain service
+// RestartSystemdService restarts a systemd service by name
 // returning error (if any)
-func RestartBlockchainService() error {
-	cmd := exec.Command("bash", "-c", "sudo systemctl restart kava")
+func RestartSystemdService(serviceName string) error {
+	cmd := exec.Command("bash", "-c", fmt.Sprintf("sudo systemctl restart %s", serviceName))
 	output, err := cmd.CombinedOutput()
-
 	if err != nil {
-		return fmt.Errorf("error %s starting blockchain service output %s", err, string(output))
+		return fmt.Errorf("error %s starting %s service output %s", err, serviceName, string(output))
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 		RPCEndpoint:                         config.KavaNodeRPCURL,
 		DefaultMonitoringIntervalSeconds:    config.DefaultMonitoringIntervalSeconds,
 		Autoheal:                            config.Autoheal,
+		AutohealBlockchainServiceName:       config.AutohealBlockchainServiceName,
 		AutohealSyncLatencyToleranceSeconds: config.AutohealSyncLatencyToleranceSeconds,
 		AutohealSyncToLiveToleranceSeconds:  config.AutohealSyncToLiveToleranceSeconds,
 		AutohealRestartDelaySeconds:         config.AutohealRestartDelaySeconds,

--- a/node.go
+++ b/node.go
@@ -326,8 +326,8 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 	}
 }
 
-// RestartBlockchainService wraps a call to restart the service
+// RestartBlockchainService restarts the blockchain's systemd service
 // returning error (if any)
 func (nc *NodeClient) RestartBlockchainService() error {
-	return heal.RestartBlockchainService()
+	return heal.RestartSystemdService("kava")
 }

--- a/node.go
+++ b/node.go
@@ -22,6 +22,7 @@ type NodeClientConfig struct {
 	RPCEndpoint                         string
 	DefaultMonitoringIntervalSeconds    int
 	Autoheal                            bool // whether doctor should take active measures to attempt to heal the kava process (e.g. place on standby if it falls significantly behind live)
+	AutohealBlockchainServiceName       string
 	AutohealSyncLatencyToleranceSeconds int
 	AutohealSyncToLiveToleranceSeconds  int
 	AutohealRestartDelaySeconds         int
@@ -329,5 +330,5 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 // RestartBlockchainService restarts the blockchain's systemd service
 // returning error (if any)
 func (nc *NodeClient) RestartBlockchainService() error {
-	return heal.RestartSystemdService("kava")
+	return heal.RestartSystemdService(nc.config.AutohealBlockchainServiceName)
 }

--- a/node.go
+++ b/node.go
@@ -123,7 +123,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 						}
 
 						// restart the node
-						err = heal.RestartBlockchainService()
+						err = nc.RestartBlockchainService()
 
 						if err != nil {
 							logMessages <- fmt.Sprintf("error %s restarting node", err)
@@ -149,7 +149,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 						// this is the first time the node is being restarted
 						// for the current downtime window
 						// restart the node
-						err = heal.RestartBlockchainService()
+						err = nc.RestartBlockchainService()
 
 						if err != nil {
 							logMessages <- fmt.Sprintf("error %s restarting node", err)
@@ -201,7 +201,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 			if currentBlockNumber > lastSynchedBlockNumber {
 				// update frozen node health indicator
 				lastNewBlockObservedAt = statusCheckEndedAt
-				logMessages <- fmt.Sprintf("node has synched new blocks since last check")
+				logMessages <- "node has synched new blocks since last check"
 			} else {
 				logMessages <- fmt.Sprintf("node has been frozen for %f seconds since %v\n NoNewBlocksRestartThresholdSeconds %d", statusCheckEndedAt.Sub(lastNewBlockObservedAt).Seconds(), lastNewBlockObservedAt, nc.config.NoNewBlocksRestartThresholdSeconds)
 			}
@@ -258,7 +258,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 			// TODO: refactor into node.AutohealFrozenNode()
 			if nc.config.Autoheal {
 				// check if the node has been frozen long enough to deserve a restart
-				frozenDuration := time.Now().Sub(lastNewBlockObservedAt)
+				frozenDuration := time.Since(lastNewBlockObservedAt)
 
 				if frozenDuration > time.Duration(time.Duration(nc.config.NoNewBlocksRestartThresholdSeconds)*time.Second) {
 					// if the node was previously restarted
@@ -272,7 +272,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 						}
 
 						// restart the node
-						err = heal.RestartBlockchainService()
+						err = nc.RestartBlockchainService()
 
 						if err != nil {
 							logMessages <- fmt.Sprintf("error %s restarting node", err)
@@ -296,7 +296,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 					logMessages <- fmt.Sprintf("autohealing frozen node, last block synched at %v,NoNewBlocksRestartThresholdSeconds %d", lastNewBlockObservedAt, nc.config.NoNewBlocksRestartThresholdSeconds)
 
 					// restart the node
-					err = heal.RestartBlockchainService()
+					err = nc.RestartBlockchainService()
 
 					if err != nil {
 						logMessages <- fmt.Sprintf("error %s restarting node", err)
@@ -324,4 +324,10 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 			lastSynchedBlockNumber = currentBlockNumber
 		}
 	}
+}
+
+// RestartBlockchainService wraps a call to restart the service
+// returning error (if any)
+func (nc *NodeClient) RestartBlockchainService() error {
+	return heal.RestartBlockchainService()
 }

--- a/node.go
+++ b/node.go
@@ -123,7 +123,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 						}
 
 						// restart the node
-						err = heal.RestartKavaService()
+						err = heal.RestartBlockchainService()
 
 						if err != nil {
 							logMessages <- fmt.Sprintf("error %s restarting node", err)
@@ -149,7 +149,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 						// this is the first time the node is being restarted
 						// for the current downtime window
 						// restart the node
-						err = heal.RestartKavaService()
+						err = heal.RestartBlockchainService()
 
 						if err != nil {
 							logMessages <- fmt.Sprintf("error %s restarting node", err)
@@ -272,7 +272,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 						}
 
 						// restart the node
-						err = heal.RestartKavaService()
+						err = heal.RestartBlockchainService()
 
 						if err != nil {
 							logMessages <- fmt.Sprintf("error %s restarting node", err)
@@ -296,7 +296,7 @@ func (nc *NodeClient) WatchSyncStatus(ctx context.Context, syncStatusMetrics cha
 					logMessages <- fmt.Sprintf("autohealing frozen node, last block synched at %v,NoNewBlocksRestartThresholdSeconds %d", lastNewBlockObservedAt, nc.config.NoNewBlocksRestartThresholdSeconds)
 
 					// restart the node
-					err = heal.RestartKavaService()
+					err = heal.RestartBlockchainService()
 
 					if err != nil {
 						logMessages <- fmt.Sprintf("error %s restarting node", err)


### PR DESCRIPTION
Adds an `autoheal_blockchain_service_name` configuration option that controls the name of the systemd service that will be restarted during the autohealing process.

The default value is the previously-hardcoded `kava` so that it is backwards compatible with configs that do not include the new option.

This allows doctor to autoheal nodes that run kava under a different service name like `cosmovisor`, or...beta software disclaimer goes here... run doctor to autoheal non-kava tendermint nodes like cosmoshub or osmosis. 😃 

If attempting to run on a non-kava tendermint node, metric collection already works. The config directory and metric namespace is all configurable via the config.json or CLI flags. I did not rename any of the `KAVA*` variables or the `kava` client, though at this point in time it would be more properly named "tendermint", as it only uses the status endpoint of the tendermint RPC.
