### PR TITLE
feat: support initial delay before 1st autoheal

### DIFF
--- a/AUTOHEALING.MD
+++ b/AUTOHEALING.MD
@@ -11,6 +11,7 @@ $ doctor --help
 Usage of doctor:
       --autoheal                                          whether doctor should take active measures to attempt to heal the kava process (e.g. place on standby if it falls significantly behind live)
       --autoheal_blockchain_service_name string           the name of the systemd service running the blockchain. this is the service that gets restarted in the autoheal process (default "kava")
+      --autoheal_initial_delay_seconds int                initial delay before autoheal attempts a restart. useful for allowing longer startup time for the chain, like during statesync initialization
       --autoheal_restart_delay_seconds int                number of seconds autohealing routines will wait to restart the endpoint, effective from the last time it was restarted and over riding the values downtime_restart_threshold_seconds no_new_blocks_restart_threshold_seconds (default 2700)
       --autoheal_sync_latency_tolerance_seconds int       how far behind live the node is allowed to fall before autohealing actions are attempted (default 120)
       --autoheal_sync_to_live_tolerance_seconds int       how close to the current time the node must resync to before being considered in sync again (default 12)
@@ -27,6 +28,8 @@ Usage of doctor:
 Only if `autoheal` is set to true will autohealing routines be triggered.
 
 Routines can run concurrently, e.g. a node may fall behind live and put on standby by one routine until it catches up, and if the node goes offline or stops making new blocks during the time it is on standby another routine will restart the kava process, and if the node syncs back to live the first auto healing process will put the node back in service with the autoscaling group.
+
+Upon initial start of the service, `autoheal` will wait `autoheal_initial_delay_seconds` before performing the first restart of the chain process.
 
 ### Node API Offline
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ $ doctor --help
 Usage of doctor:
       --autoheal                                          whether doctor should take active measures to attempt to heal the kava process (e.g. place on standby if it falls significantly behind live)
       --autoheal_blockchain_service_name string           the name of the systemd service running the blockchain. this is the service that gets restarted in the autoheal process (default "kava")
+      --autoheal_initial_delay_seconds int                initial delay before autoheal attempts a restart. useful for allowing longer startup time for the chain, like during statesync initialization
       --autoheal_restart_delay_seconds int                number of seconds autohealing routines will wait to restart the endpoint, effective from the last time it was restarted and over riding the values downtime_restart_threshold_seconds no_new_blocks_restart_threshold_seconds (default 2700)
       --autoheal_sync_latency_tolerance_seconds int       how far behind live the node is allowed to fall before autohealing actions are attempted (default 120)
       --autoheal_sync_to_live_tolerance_seconds int       how close to the current time the node must resync to before being considered in sync again (default 12)

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ const (
 	AutohealBlockchainServiceNameFlagName              = "autoheal_blockchain_service_name"
 	AutohealSyncLatencyToleranceSecondsFlagName        = "autoheal_sync_latency_tolerance_seconds"
 	AutohealSyncToLiveToleranceSecondsFlagName         = "autoheal_sync_to_live_tolerance_seconds"
+	AutohealInitialDelaySecondsFlagName                = "autoheal_initial_delay_seconds"
 	DowntimeRestartThresholdSecondsFlagName            = "downtime_restart_threshold_seconds"
 	// 5 minutes
 	DefaultDowntimeRestartThresholdSeconds     = 300
@@ -81,6 +82,7 @@ var (
 	autohealBlockchainServiceNameFlag              = flag.String(AutohealBlockchainServiceNameFlagName, "kava", "the name of the systemd service running the blockchain. this is the service that gets restarted in the autoheal process")
 	autohealSyncLatencyToleranceSecondsFlag        = flag.Int(AutohealSyncLatencyToleranceSecondsFlagName, 120, "how far behind live the node is allowed to fall before autohealing actions are attempted")
 	autohealSyncToLiveToleranceSecondsFlag         = flag.Int(AutohealSyncToLiveToleranceSecondsFlagName, 12, "how close to the current time the node must resync to before being considered in sync again")
+	autohealInitialDelaySecondsFlag                = flag.Int(AutohealInitialDelaySecondsFlagName, 0, "initial delay before autoheal attempts a restart. useful for allowing longer startup time for the chain, like during statesync initialization")
 	downtimeRestartThresholdSecondsFlag            = flag.Int(DowntimeRestartThresholdSecondsFlagName, DefaultDowntimeRestartThresholdSeconds, "how many continuous seconds the endpoint being monitored has to be offline or unresponsive before autohealing will be attempted")
 	noNewBlocksRestartThresholdSecondsFlag         = flag.Int(NoNewBlocksRestartThresholdSecondsFlagName, DefaultNoNewBlocksRestartThresholdSeconds, "how many continuous seconds the endpoint being monitored has not produce a new bloc before autohealing will be attempted")
 	healthChecksTimeoutSecondsFlag                 = flag.Int(HealthChecksTimeoutSecondsFlagName, DefaultHealthChecksTimeoutSecondsFlagName, "max number of seconds doctor will wait for a health check response from the endpoint")
@@ -105,6 +107,7 @@ type DoctorConfig struct {
 	AutohealSyncLatencyToleranceSeconds        int
 	AutohealSyncToLiveToleranceSeconds         int
 	AutohealRestartDelaySeconds                int
+	AutohealInitialAllowedDelaySeconds         int
 	HealthChecksTimeoutSeconds                 int
 	NoNewBlocksRestartThresholdSeconds         int
 	DowntimeRestartThresholdSeconds            int
@@ -205,6 +208,7 @@ func GetDoctorConfig() (*DoctorConfig, error) {
 		AutohealSyncLatencyToleranceSeconds: viper.GetInt(AutohealSyncLatencyToleranceSecondsFlagName),
 		AutohealSyncToLiveToleranceSeconds:  viper.GetInt(AutohealSyncToLiveToleranceSecondsFlagName),
 		AutohealRestartDelaySeconds:         viper.GetInt(AutohealRestartDelaySecondsFlagName),
+		AutohealInitialAllowedDelaySeconds:  viper.GetInt(AutohealInitialDelaySecondsFlagName),
 		HealthChecksTimeoutSeconds:          viper.GetInt(HealthChecksTimeoutSecondsFlagName),
 		NoNewBlocksRestartThresholdSeconds:  viper.GetInt(NoNewBlocksRestartThresholdSecondsFlagName),
 		DowntimeRestartThresholdSeconds:     viper.GetInt(DowntimeRestartThresholdSecondsFlagName),

--- a/heal/heal.go
+++ b/heal/heal.go
@@ -41,11 +41,11 @@ func GetNodeAutoscalingState(instanceId string, client *autoscaling.AutoScaling)
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("StandbyNodeUntilCaughtUp: error %s checking autoscaling state for instance %s", err, instanceId)
+		return "", fmt.Errorf("GetNodeAutoscalingState: error %s checking autoscaling state for instance %s", err, instanceId)
 	}
 
 	if len(autoscalingInstances.AutoScalingInstances) != 1 {
-		return "", fmt.Errorf("StandbyNodeUntilCaughtUp: expected exactly one instance with id %s, got %+v", instanceId, autoscalingInstances.AutoScalingInstances)
+		return "", fmt.Errorf("GetNodeAutoscalingState: expected exactly one instance with id %s, got %+v", instanceId, autoscalingInstances.AutoScalingInstances)
 	}
 
 	return *autoscalingInstances.AutoScalingInstances[0].LifecycleState, nil

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 		AutohealSyncLatencyToleranceSeconds: config.AutohealSyncLatencyToleranceSeconds,
 		AutohealSyncToLiveToleranceSeconds:  config.AutohealSyncToLiveToleranceSeconds,
 		AutohealRestartDelaySeconds:         config.AutohealRestartDelaySeconds,
+		AutohealInitialAllowedDelaySeconds:  config.AutohealInitialAllowedDelaySeconds,
 		HealthChecksTimeoutSeconds:          config.HealthChecksTimeoutSeconds,
 		NoNewBlocksRestartThresholdSeconds:  config.NoNewBlocksRestartThresholdSeconds,
 		DowntimeRestartThresholdSeconds:     config.DowntimeRestartThresholdSeconds,


### PR DESCRIPTION
adds `autoheal_initial_delay_seconds` configuration option which is the amount of seconds doctor will always wait before the very first restart of the chain service is performed.

this is particularly useful for situations that require a longer startup time, like during statesync initialization.